### PR TITLE
Change database names to distinguish from group project db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
 development:
   <<: *default
-  database: monster_shop_first_half_development
+  database: monster_shop_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: monster_shop_first_half_testing
+  database: monster_shop_testing
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: monster_shop_first_half_production
-  username: monster_shop_first_half
-  password: <%= ENV['MONSTER_SHOP_FIRST_HALF_DATABASE_PASSWORD'] %>
+  database: monster_shop_production
+  username: monster_shop
+  password: <%= ENV['MONSTER_SHOP_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
## Description
Changes database names in config/database.yml in order to differentiate this project's PostrgresQL databases from those of the group project which this forked from.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## RSpec Results
```
Finished in 12.09 seconds (files took 2.3 seconds to load)
240 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/2module/projects/monster_shop/coverage. 2882 / 2882 LOC (100.0%) covered.
```
